### PR TITLE
Restore window proc when detaching

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1342,6 +1342,12 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID) {
             monitorThread.join();
         }
 
+        if (hwnd && oWndProc) {
+            SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)oWndProc);
+            oWndProc = nullptr;
+            hwnd = nullptr;
+        }
+
         // Remove all breakpoints on exit
         for (auto& pair : breakpointInfo) {
             DWORD address = pair.first;


### PR DESCRIPTION
## Summary
- restore the original window procedure when the DLL is unloaded

## Testing
- `git status --short`
