### PR TITLE
Handle io.open failures

### DIFF
--- a/plugins/telemetry_logger.lua
+++ b/plugins/telemetry_logger.lua
@@ -48,16 +48,23 @@ local curLap
 local index = 0
 local file
 local points = {}
+local status = 'Waiting...'
 
 local function openLap(lap)
     if file then file:close() end
     local path = string.format('telemetry_lap_%d.csv', lap)
     file = io.open(path, 'w')
-    if file then
-        file:write('index,x,y,z,speed,gear,throttle,brake,drs,kers\n')
+    if not file then
+        status = string.format('Failed to open %s', path)
+        SCRIPT_RESULT = status
+        return false
     end
+    file:write('index,x,y,z,speed,gear,throttle,brake,drs,kers\n')
     points = {}
     index = 0
+    status = string.format('Lap %d: %d samples', lap, index)
+    SCRIPT_RESULT = status
+    return true
 end
 
 local function writeObj(lap)
@@ -73,11 +80,15 @@ end
 
 function OnFrame()
     frame = frame + 1
-    if frame % 5 ~= 0 then return true end
+    if frame % 5 ~= 0 then
+        SCRIPT_RESULT = status
+        return true
+    end
 
     local cBase = carBase()
     if not cBase then
-        SCRIPT_RESULT = 'Waiting for car...'
+        status = 'Waiting for car...'
+        SCRIPT_RESULT = status
         return true
     end
 
@@ -85,9 +96,14 @@ function OnFrame()
     if curLap ~= lap then
         if curLap then writeObj(curLap) end
         curLap = lap
-        openLap(lap)
+        if not openLap(lap) then
+            return true
+        end
     end
-    if not file then return true end
+    if not file then
+        SCRIPT_RESULT = status
+        return true
+    end
 
     local x = readFloat(cBase + 0x1A0)
     local y = readFloat(cBase + 0x1A4)
@@ -113,6 +129,19 @@ function OnFrame()
         index, x, y, z, speed, gear, throttle, brake, drs, kers))
     table.insert(points, {x, y, z})
 
-    SCRIPT_RESULT = string.format('Lap %d: %d samples', curLap, index)
+    status = string.format('Lap %d: %d samples', curLap, index)
+    SCRIPT_RESULT = status
     return true
+end
+
+function OnPluginEnd()
+    if file then
+        file:close()
+        file = nil
+    end
+    if curLap then
+        writeObj(curLap)
+    end
+    status = 'Telemetry log saved'
+    SCRIPT_RESULT = status
 end


### PR DESCRIPTION
## Summary
- check file handle when opening telemetry log
- close file and export OBJ when plugin ends
- maintain status across frames to stop reloads

## Testing
- `git status --short`