### PR TITLE
Add debug logging for telemetry addresses

### DIFF
--- a/plugins/telemetry_logger.lua
+++ b/plugins/telemetry_logger.lua
@@ -1,5 +1,16 @@
 local ffi = require('ffi')
 
+local function writeLog(message, clear)
+    local mode = clear and 'w' or 'a'
+    local logFile = io.open('telemetry_debug.log', mode)
+    if logFile then
+        logFile:write(os.date('%Y-%m-%d %H:%M:%S') .. ': ' .. message .. '\n')
+        logFile:close()
+    end
+end
+
+writeLog('Starting new session', true)
+
 -- simple ini parser for controls section
 local function parseIni(path)
     local data = {}
@@ -74,12 +85,18 @@ local function carBase()
     return resolve(base + 0xDD5ABC, {0x50, 0x4A8, 0x38})
 end
 
-local function lapNumber()
+local function lapAddr()
     local ptr = readPtr(base + 0xDD5A94)
     if not ptr then return nil end
     ptr = readPtr(ptr + 0x78)
     if not ptr then return nil end
-    return Memory.ReadMemory(ptr + 0xA18, 4)
+    return ptr + 0xA18
+end
+
+local function lapNumber()
+    local addr = lapAddr()
+    if not addr then return nil end
+    return Memory.ReadMemory(addr, 4), addr
 end
 
 local function speedAddr()
@@ -90,6 +107,14 @@ end
 
 local function gearBase()
     return resolve(base + 0xDD0D28, {0x24, 0x20, 0x70, 0x10, 0x38})
+end
+
+local function throttleAddr()
+    return resolve(base + 0xD9A6D8, {0x64, 0x78, 0x8, 0x4, 0x4C})
+end
+
+local function brakeAddr()
+    return resolve(base + 0xD96F94, {0xF0, 0x8, 0x3C, 0x60, 0x4C, 0x4})
 end
 
 local frame = 0
@@ -153,7 +178,8 @@ function OnFrame()
         return true
     end
 
-    local lap = lapNumber() or 0
+    local lap, lapPtr = lapNumber()
+    lap = lap or 0
     if curLap ~= lap then
         if curLap then
             writeObj(curLap)
@@ -187,14 +213,20 @@ function OnFrame()
     local gBase = gearBase()
     local gear = gBase and Memory.ReadMemory(gBase + 0x244, 4) or 0
 
-    local thrPtr = resolve(base + 0xD9A6D8, {0x64,0x78,0x8,0x4,0x4C})
+    local thrPtr = throttleAddr()
     local throttle = thrPtr and readFloat(thrPtr + 0x8) or 0
 
-    local brkPtr = resolve(base + 0xD96F94, {0xF0,0x8,0x3C,0x60,0x4C,0x4})
+    local brkPtr = brakeAddr()
     local brake = brkPtr and readFloat(brkPtr + 0x8) or 0
 
     local drs = gBase and Memory.ReadMemory(gBase + 0x29C, 4) or 0
     local kers = gBase and Memory.ReadMemory(gBase + 0x294, 4) or 0
+
+    writeLog(string.format(
+        'cBase=0x%X lapPtr=0x%X lap=%d sAddr=0x%X speed=%.3f gBase=0x%X gear=%d '
+        .. 'thrPtr=0x%X throttle=%.2f brkPtr=0x%X brake=%.2f drs=%d kers=%d',
+        cBase or 0, lapPtr or 0, lap, sAddr or 0, speed, gBase or 0, gear,
+        thrPtr or 0, throttle, brkPtr or 0, brake, drs, kers))
 
     index = index + 1
     file:write(string.format('%d,%.6f,%.6f,%.6f,%.3f,%d,%.2f,%.2f,%d,%d\n',


### PR DESCRIPTION
## Summary
- log session info to `telemetry_debug.log`
- expose lap address and helper functions for throttle/brake
- write address and value information each sample

## Testing
- `git status --short`