### PR TITLE
Add debug output

### DIFF
--- a/plugins/telemetry_logger.lua
+++ b/plugins/telemetry_logger.lua
@@ -1,5 +1,6 @@
 local ffi = require('ffi')
 
+
 -- simple ini parser for controls section
 local function parseIni(path)
     local data = {}
@@ -74,12 +75,18 @@ local function carBase()
     return resolve(base + 0xDD5ABC, {0x50, 0x4A8, 0x38})
 end
 
-local function lapNumber()
+local function lapAddr()
     local ptr = readPtr(base + 0xDD5A94)
     if not ptr then return nil end
     ptr = readPtr(ptr + 0x78)
     if not ptr then return nil end
-    return Memory.ReadMemory(ptr + 0xA18, 4)
+    return ptr + 0xA18
+end
+
+local function lapNumber()
+    local addr = lapAddr()
+    if not addr then return nil end
+    return Memory.ReadMemory(addr, 4), addr
 end
 
 local function speedAddr()
@@ -92,11 +99,32 @@ local function gearBase()
     return resolve(base + 0xDD0D28, {0x24, 0x20, 0x70, 0x10, 0x38})
 end
 
+local function throttleAddr()
+    return resolve(base + 0xD9A6D8, {0x64, 0x78, 0x8, 0x4, 0x4C})
+end
+
+local function brakeAddr()
+    return resolve(base + 0xD96F94, {0xF0, 0x8, 0x3C, 0x60, 0x4C, 0x4})
+end
+
 local frame = 0
+local active = false
 local curLap
 local index = 0
 local file
 local points = {}
+local debugStr = ''
+
+local function updateDebug(cBase, lapPtr, lap, sAddr, speed, gBase, gear,
+    thrPtr, throttle, brkPtr, brake, drs, kers)
+    debugStr = string.format(
+        'Current data: cBase=0x%X lapPtr=0x%X lap=%d sAddr=0x%X speed=%.3f '
+        ..'gBase=0x%X gear=%d thrPtr=0x%X throttle=%.2f brkPtr=0x%X '
+        ..'brake=%.2f drs=%d kers=%d',
+        cBase or 0, lapPtr or 0, lap or 0, sAddr or 0, speed or 0,
+        gBase or 0, gear or 0, thrPtr or 0, throttle or 0,
+        brkPtr or 0, brake or 0, drs or 0, kers or 0)
+end
 local function openLap(lap)
     if file then file:close() end
     local path = string.format('telemetry_lap_%d.csv', lap)
@@ -104,7 +132,7 @@ local function openLap(lap)
     if not file then
 
         status = string.format('Failed to open %s', path)
-        SCRIPT_RESULT = status
+        SCRIPT_RESULT = status .. '\n' .. debugStr
 
         return false
     end
@@ -113,7 +141,7 @@ local function openLap(lap)
     index = 0
 
     status = string.format('Lap %d: %d samples', lap, index)
-    SCRIPT_RESULT = status
+    SCRIPT_RESULT = status .. '\n' .. debugStr
 
     return true
 end
@@ -134,7 +162,9 @@ function OnFrame()
     if not active then
         if Keyboard.IsKeyPressed(startKey) then
             active = true
-            SCRIPT_RESULT = 'Logging started'
+            status = 'Waiting for car...'
+            updateDebug()
+            SCRIPT_RESULT = status .. '\n' .. debugStr
         else
             SCRIPT_RESULT = status
         end
@@ -142,18 +172,20 @@ function OnFrame()
     end
 
     if frame % 5 ~= 0 then
-        SCRIPT_RESULT = status
+        SCRIPT_RESULT = status .. '\n' .. debugStr
         return true
     end
 
     local cBase = carBase()
     if not cBase then
         status = 'Waiting for car...'
-        SCRIPT_RESULT = status
+        updateDebug()
+        SCRIPT_RESULT = status .. '\n' .. debugStr
         return true
     end
 
-    local lap = lapNumber() or 0
+    local lap, lapPtr = lapNumber()
+    lap = lap or 0
     if curLap ~= lap then
         if curLap then
             writeObj(curLap)
@@ -172,7 +204,7 @@ function OnFrame()
         end
     end
     if not file then
-        SCRIPT_RESULT = status
+        SCRIPT_RESULT = status .. '\n' .. debugStr
         return true
 
     end
@@ -187,14 +219,17 @@ function OnFrame()
     local gBase = gearBase()
     local gear = gBase and Memory.ReadMemory(gBase + 0x244, 4) or 0
 
-    local thrPtr = resolve(base + 0xD9A6D8, {0x64,0x78,0x8,0x4,0x4C})
+    local thrPtr = throttleAddr()
     local throttle = thrPtr and readFloat(thrPtr + 0x8) or 0
 
-    local brkPtr = resolve(base + 0xD96F94, {0xF0,0x8,0x3C,0x60,0x4C,0x4})
+    local brkPtr = brakeAddr()
     local brake = brkPtr and readFloat(brkPtr + 0x8) or 0
 
     local drs = gBase and Memory.ReadMemory(gBase + 0x29C, 4) or 0
     local kers = gBase and Memory.ReadMemory(gBase + 0x294, 4) or 0
+
+    updateDebug(cBase, lapPtr, lap, sAddr, speed, gBase, gear,
+        thrPtr, throttle, brkPtr, brake, drs, kers)
 
     index = index + 1
     file:write(string.format('%d,%.6f,%.6f,%.6f,%.3f,%d,%.2f,%.2f,%d,%d\n',
@@ -202,7 +237,7 @@ function OnFrame()
     table.insert(points, {x, y, z})
 
     status = string.format('Lap %d: %d samples', curLap, index)
-    SCRIPT_RESULT = status
+    SCRIPT_RESULT = status .. '\n' .. debugStr
     return true
 end
 


### PR DESCRIPTION
## Summary
- display telemetry memory addresses and values directly in plugin status
- show debug info when logging is active

## Testing
- `git status --short`