### PR TITLE
Improve debug output for telemetry

### DIFF
--- a/plugins/telemetry_logger.lua
+++ b/plugins/telemetry_logger.lua
@@ -1,5 +1,16 @@
 local ffi = require('ffi')
 
+local function writeLog(message, clear)
+    local mode = clear and 'w' or 'a'
+    local logFile = io.open('telemetry_debug.log', mode)
+    if logFile then
+        logFile:write(os.date('%Y-%m-%d %H:%M:%S') .. ': ' .. message .. '\n')
+        logFile:close()
+    end
+end
+
+writeLog('Starting new session', true)
+
 -- simple ini parser for controls section
 local function parseIni(path)
     local data = {}
@@ -74,12 +85,18 @@ local function carBase()
     return resolve(base + 0xDD5ABC, {0x50, 0x4A8, 0x38})
 end
 
-local function lapNumber()
+local function lapAddr()
     local ptr = readPtr(base + 0xDD5A94)
     if not ptr then return nil end
     ptr = readPtr(ptr + 0x78)
     if not ptr then return nil end
-    return Memory.ReadMemory(ptr + 0xA18, 4)
+    return ptr + 0xA18
+end
+
+local function lapNumber()
+    local addr = lapAddr()
+    if not addr then return nil end
+    return Memory.ReadMemory(addr, 4), addr
 end
 
 local function speedAddr()
@@ -92,11 +109,31 @@ local function gearBase()
     return resolve(base + 0xDD0D28, {0x24, 0x20, 0x70, 0x10, 0x38})
 end
 
+local function throttleAddr()
+    return resolve(base + 0xD9A6D8, {0x64, 0x78, 0x8, 0x4, 0x4C})
+end
+
+local function brakeAddr()
+    return resolve(base + 0xD96F94, {0xF0, 0x8, 0x3C, 0x60, 0x4C, 0x4})
+end
+
 local frame = 0
 local curLap
 local index = 0
 local file
 local points = {}
+local active = false
+local debugStr = ''
+
+local function updateDebug(cBase, lapPtr, lap, sAddr, speed, gBase, gear,
+    thrPtr, throttle, brkPtr, brake, drs, kers)
+    debugStr = string.format(
+        'cBase=0x%X lapPtr=0x%X lap=%d sAddr=0x%X speed=%.3f gBase=0x%X gear=%d '
+        .. 'thrPtr=0x%X throttle=%.2f brkPtr=0x%X brake=%.2f drs=%d kers=%d',
+        cBase or 0, lapPtr or 0, lap or 0, sAddr or 0, speed or 0,
+        gBase or 0, gear or 0, thrPtr or 0, throttle or 0, brkPtr or 0,
+        brake or 0, drs or 0, kers or 0)
+end
 local function openLap(lap)
     if file then file:close() end
     local path = string.format('telemetry_lap_%d.csv', lap)
@@ -104,7 +141,7 @@ local function openLap(lap)
     if not file then
 
         status = string.format('Failed to open %s', path)
-        SCRIPT_RESULT = status
+        SCRIPT_RESULT = status .. '\n' .. debugStr
 
         return false
     end
@@ -113,7 +150,7 @@ local function openLap(lap)
     index = 0
 
     status = string.format('Lap %d: %d samples', lap, index)
-    SCRIPT_RESULT = status
+    SCRIPT_RESULT = status .. '\n' .. debugStr
 
     return true
 end
@@ -135,6 +172,7 @@ function OnFrame()
         if Keyboard.IsKeyPressed(startKey) then
             active = true
             SCRIPT_RESULT = 'Logging started'
+            debugStr = ''
         else
             SCRIPT_RESULT = status
         end
@@ -142,18 +180,33 @@ function OnFrame()
     end
 
     if frame % 5 ~= 0 then
-        SCRIPT_RESULT = status
+        SCRIPT_RESULT = status .. '\n' .. debugStr
         return true
     end
 
     local cBase = carBase()
+    local lap, lapPtr = lapNumber()
+    lap = lap or 0
+    local sAddr = speedAddr()
+    local speed = sAddr and readFloat(sAddr) or 0
+    local gBase = gearBase()
+    local gear = gBase and Memory.ReadMemory(gBase + 0x244, 4) or 0
+    local thrPtr = throttleAddr()
+    local throttle = thrPtr and readFloat(thrPtr + 0x8) or 0
+    local brkPtr = brakeAddr()
+    local brake = brkPtr and readFloat(brkPtr + 0x8) or 0
+    local drs = gBase and Memory.ReadMemory(gBase + 0x29C, 4) or 0
+    local kers = gBase and Memory.ReadMemory(gBase + 0x294, 4) or 0
+
+    updateDebug(cBase, lapPtr, lap, sAddr, speed, gBase, gear,
+        thrPtr, throttle, brkPtr, brake, drs, kers)
+    writeLog(debugStr)
+
     if not cBase then
         status = 'Waiting for car...'
-        SCRIPT_RESULT = status
+        SCRIPT_RESULT = status .. '\n' .. debugStr
         return true
     end
-
-    local lap = lapNumber() or 0
     if curLap ~= lap then
         if curLap then
             writeObj(curLap)
@@ -172,29 +225,15 @@ function OnFrame()
         end
     end
     if not file then
-        SCRIPT_RESULT = status
+        SCRIPT_RESULT = status .. "\n" .. debugStr
         return true
 
     end
 
+
     local x = readFloat(cBase + 0x1A0)
     local y = readFloat(cBase + 0x1A4)
     local z = readFloat(cBase + 0x1A8)
-
-    local sAddr = speedAddr()
-    local speed = sAddr and readFloat(sAddr) or 0
-
-    local gBase = gearBase()
-    local gear = gBase and Memory.ReadMemory(gBase + 0x244, 4) or 0
-
-    local thrPtr = resolve(base + 0xD9A6D8, {0x64,0x78,0x8,0x4,0x4C})
-    local throttle = thrPtr and readFloat(thrPtr + 0x8) or 0
-
-    local brkPtr = resolve(base + 0xD96F94, {0xF0,0x8,0x3C,0x60,0x4C,0x4})
-    local brake = brkPtr and readFloat(brkPtr + 0x8) or 0
-
-    local drs = gBase and Memory.ReadMemory(gBase + 0x29C, 4) or 0
-    local kers = gBase and Memory.ReadMemory(gBase + 0x294, 4) or 0
 
     index = index + 1
     file:write(string.format('%d,%.6f,%.6f,%.6f,%.3f,%d,%.2f,%.2f,%d,%d\n',
@@ -202,7 +241,7 @@ function OnFrame()
     table.insert(points, {x, y, z})
 
     status = string.format('Lap %d: %d samples', curLap, index)
-    SCRIPT_RESULT = status
+    SCRIPT_RESULT = status .. '\n' .. debugStr
     return true
 end
 


### PR DESCRIPTION
## Summary
- track logging state and debug text
- log memory addresses every frame
- show addresses and values in plugin status

## Testing
- `git status --short`