### PR TITLE
Improve pssg2fs path logic

### DIFF
--- a/plugins/pssg2fs.ini
+++ b/plugins/pssg2fs.ini
@@ -1,0 +1,8 @@
+[meta]
+name=PSSG to FileSystem
+version=1.0
+author=Alexey Savelyev
+
+[status]
+info=Redirects PSSG loads to plugins/pssg2fs when files are found.
+pluginStatus=Loading...

--- a/plugins/pssg2fs.lua
+++ b/plugins/pssg2fs.lua
@@ -1,0 +1,73 @@
+local ffi = require('ffi')
+local kernel32 = ffi.load('kernel32')
+
+ffi.cdef[[
+unsigned int GetModuleFileNameA(void* hModule, char* lpFilename, unsigned int size);
+]]
+
+local pluginDir = debug.getinfo(1, 'S').source:match('@(.+)[/\\]')
+local basePath = pluginDir .. '/pssg2fs/'
+
+local exeBase = Memory.GetModuleBase('F1_2012.exe')
+local buf = ffi.new('char[260]')
+local gameDir = ''
+if exeBase then
+    kernel32.GetModuleFileNameA(ffi.cast('void*', exeBase), buf, 260)
+    local exePath = ffi.string(buf)
+    gameDir = exePath:match('^(.*)[/\\][^/\\]+$') or ''
+end
+
+local function escapePattern(text)
+    return text:gsub('([%^%$%(%)%%%.%[%]%*%+%-%?])', '%%%1')
+end
+
+local breakpointSet = false
+
+local function readString(addr)
+    local bytes = {}
+    local offset = 0
+    while true do
+        local b = Memory.ReadMemory(addr + offset, 1)
+        if not b or b == 0 then break end
+        bytes[#bytes + 1] = string.char(b)
+        offset = offset + 1
+    end
+    return table.concat(bytes)
+end
+
+function OnBreakpoint(address)
+    local regs = Registers.Get()
+    local ptr = Memory.ReadMemory(regs.esp + 4, 4)
+    if not ptr or ptr == 0 then return end
+    local original = readString(ptr)
+    local relative = original
+    if gameDir ~= '' then
+        local pattern = '^' .. escapePattern(gameDir) .. '[\\/]*'
+        relative = relative:gsub(pattern, '')
+    end
+    local newPath = basePath .. relative
+    local file = io.open(newPath, 'rb')
+    if file then
+        file:close()
+        local mem = Memory.AllocateMemory(#newPath + 1)
+        for i = 1, #newPath do
+            Memory.WriteMemory(mem + i - 1, newPath:byte(i), 1)
+        end
+        Memory.WriteMemory(mem + #newPath, 0, 1)
+        Memory.WriteMemory(regs.esp + 4, mem, 4)
+    end
+end
+
+function OnFrame()
+    if not breakpointSet then
+        local base = Memory.GetModuleBase('F1_2012.exe')
+        if base and Debug.SetBreakpoint(base + 0x4C2706, 'OnBreakpoint') then
+            SCRIPT_RESULT = 'pssg2fs active'
+            breakpointSet = true
+        else
+            SCRIPT_RESULT = 'pssg2fs failed'
+        end
+        return true
+    end
+    return false
+end


### PR DESCRIPTION
## Summary
- adjust pssg2fs plugin to handle absolute paths
- use game's base address for breakpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846a401b2b8832599114d7ec12deb9b